### PR TITLE
(PA-5784) Update submodules to latest version and run 'ruby install.rb'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -462,14 +462,13 @@ if true; then
 
     major_version=`echo $platform_version | cut -d. -f1,2`
 
-    # Excepting macOS 10.x, the major version is the first number only
-    if ! echo "${major_version}" | grep -q '^10\.'; then
-        major_version=$(echo "${major_version}" | cut -d '.' -f 1);
-    fi
+    # The major version is the first number only
+    major_version=$(echo "${major_version}" | cut -d '.' -f 1);
 
     case $major_version in
       "11")    platform_version="11";;
       "12")    platform_version="12";;
+      "13")    platform_version="13";;
       *) echo "No builds for platform: $major_version"
          exit 1
          ;;


### PR DESCRIPTION
- This adds supports for macOS 13 and removes support for macOS 10.x