### PR TITLE
Sync puppet_agent install script, add debian 12 to litmus tests

### DIFF
--- a/.github/workflows/install_puppet.yaml
+++ b/.github/workflows/install_puppet.yaml
@@ -20,6 +20,7 @@ jobs:
           { name: "CentOS 7", image: "litmusimage/centos:7" },
           { name: "Debian 10", image: "litmusimage/debian:10" },
           { name: "Debian 11", image: "litmusimage/debian:11" },
+          { name: "Debian 12", image: "litmusimage/debian:12" },
           { name: "Ubuntu 18.04", image: "litmusimage/ubuntu:18.04" },
           { name: "Ubuntu 20.04", image: "litmusimage/ubuntu:20.04" },
           { name: "Ubuntu 22.04", image: "litmusimage/ubuntu:22.04" },

--- a/install.sh
+++ b/install.sh
@@ -301,14 +301,25 @@ assert_unmodified_apt_config() {
   fi
 }
 
+# Check whether python3 and urllib.request are available
+exists_python3_urllib() {
+  python3 -c 'import urllib.request' >/dev/null 2>&1
+}
+
 # Check whether perl and LWP::Simple module are installed
-exists_perl() {
-  if perl -e 'use LWP::Simple;' >/dev/null 2>&1
-  then
+exists_perl_lwp() {
+  if perl -e 'use LWP::Simple;' >/dev/null 2>&1 ; then
     return 0
-  else
-    return 1
   fi
+  return 1
+}
+
+# Check whether perl and File::Fetch module are installed
+exists_perl_ff() {
+  if perl -e 'use File::Fetch;' >/dev/null 2>&1 ; then
+    return 0
+  fi
+  return 1
 }
 
 # Get command line arguments
@@ -368,7 +379,7 @@ fi
 # Track to handle puppet5 to puppet6
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
   installed_version=`cat /opt/puppetlabs/puppet/VERSION`
-elif which puppet >/dev/null 2>&1; then
+elif type -p puppet >/dev/null; then
   installed_version=`puppet --version`
 else
   installed_version=uninstalled
@@ -656,9 +667,28 @@ do_fetch() {
   return 0
 }
 
-# do_perl URL FILENAME
-do_perl() {
-  info "Trying perl..."
+do_python3_urllib() {
+  info "Trying python3 (urllib.request)..."
+  run_cmd "python3 -c 'import urllib.request ; urllib.request.urlretrieve(\"$1\", \"$2\")'" 2>$tmp_stderr
+  rc=$?
+
+  # check for 404
+  if grep "404: Not Found" $tmp_stderr 2>&1 >/dev/null ; then
+    critical "ERROR 404"
+    unable_to_retrieve_package
+  fi
+
+  if test $rc -eq 0 && test -s "$2" ; then
+    return 0
+  fi
+
+  capture_tmp_stderr "perl"
+  return 1
+}
+
+# do_perl_lwp URL FILENAME
+do_perl_lwp() {
+  info "Trying perl (LWP::Simple)..."
   run_cmd "perl -e 'use LWP::Simple; getprint(\$ARGV[0]);' '$1' > '$2' 2>$tmp_stderr"
   rc=$?
 
@@ -669,13 +699,33 @@ do_perl() {
     unable_to_retrieve_package
   fi
 
-  # check for bad return status or empty output
-  if test $rc -ne 0 || test ! -s "$2"; then
-    capture_tmp_stderr "perl"
-    return 1
+  if test $rc -eq 0 && test -s "$2" ; then
+    return 0
   fi
 
-  return 0
+  capture_tmp_stderr "perl"
+  return 1
+}
+
+# do_perl_ff URL FILENAME
+do_perl_ff() {
+  info "Trying perl (File::Fetch)..."
+  run_cmd "perl -e 'use File::Fetch; use File::Copy; my \$ff = File::Fetch->new(uri => \$ARGV[0]); my \$outfile = \$ff->fetch() or die \$ff->server; copy(\$outfile, \$ARGV[1]) or die \"copy failed: \$!\"; unlink(\$outfile) or die \"delete failed: \$!\";' '$1' '$2' 2>>$tmp_stderr"
+  rc=$?
+
+  # check for 404
+  grep "HTTP response: 404" $tmp_stderr 2>&1 >/dev/null
+  if test $? -eq 0 ; then
+    critical "ERROR 404"
+    unable_to_retrieve_package
+  fi
+
+  if test $rc -eq 0 && test -s "$2" ; then
+    return 0
+  fi
+
+  capture_tmp_stderr "perl"
+  return 1
 }
 
 # do_download URL FILENAME
@@ -698,11 +748,19 @@ do_download() {
     do_fetch $1 $2 && return 0
   fi
 
-  if exists_perl; then
-    do_perl $1 $2 && return 0
+  if exists_perl_lwp; then
+    do_perl_lwp $1 $2 && return 0
   fi
 
-  critical "Cannot download package as none of wget/curl/fetch/perl-LWP-Simple is found"
+  if exists_perl_ff; then
+    do_perl_ff $1 $2 && return 0
+  fi
+
+  if exists_python3_urllib; then
+    do_python3_urllib $1 $2 && return 0
+  fi
+
+  critical "Cannot download package as none of wget/curl/fetch/perl-LWP-Simple/perl-File-Fetch/python3 is found"
   unable_to_retrieve_package
 }
 


### PR DESCRIPTION
This PR bumps the puppet_agent module version to include support for Debian Bookworm.

This fixes #7

This was generated by updating the puppet_agent submodule and running `ruby install.rb`.