### PR TITLE
(maint) Added unicorn team under codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @puppetlabs/phoenix
+* @puppetlabs/phoenix @puppetlabs/Unicorn


### PR DESCRIPTION
updated CODEOWNERS file to accommodate @puppetlabs/unicorn group.

Reason being, we update similar sort of content most of the time and if the code changes looks straight forward Unicorn team can review internally and merge the changes rather waiting for team from US to login. This would save considerable time in platform addition.