### PR TITLE
(PA-6623) Update puppet-agent submodule and install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -344,7 +344,7 @@ if [ -n "$PT_yum_source" ]; then
   yum_source=$PT_yum_source
 else
   if [ "$nightly" = true ]; then
-    yum_source='http://nightlies.puppet.com/yum'
+    yum_source='https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum'
   else
     yum_source='http://yum.puppet.com'
   fi


### PR DESCRIPTION
This adds support for Fedora 41 nightly since its rpms are available at artifactory.