### PR TITLE
(PA-8923) Remove EOL macOS versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -513,9 +513,6 @@ if true; then
     major_version=$(echo "${major_version}" | cut -d '.' -f 1);
 
     case $major_version in
-      "11")    platform_version="11";;
-      "12")    platform_version="12";;
-      "13")    platform_version="13";;
       "14")    platform_version="14";;
       "15")    platform_version="15";;
       "26")    platform_version="26";;


### PR DESCRIPTION
This commit removes support for macOS 11 (Big Sur), 12 (Monterey), and 13 (Ventura), all of which are end-of-life.